### PR TITLE
directly specify files for ripgrep, so it should not wait for stdin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,10 +69,12 @@ export function ripGrep(cwd: string, optionsOrSearchTerm: Options | string): Pro
     execString = `${execString} --multiline`;
   }
 
+  execString+=` -- ${cwd}`
+
   execLog(execString);
 
   return new Promise(function (resolve, reject) {
-    exec(execString, { cwd }, (error, stdout, stderr) => {
+    exec(execString, (error, stdout, stderr) => {
       if (!error || (error && stderr === '')) {
         resolve(formatResults(stdout));
       } else {


### PR DESCRIPTION
Fixes #174 