### PR TITLE
feat: add Options.env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ export function ripGrep(cwd: string, optionsOrSearchTerm: Options | string): Pro
   execLog(execString);
 
   return new Promise(function (resolve, reject) {
-    exec(execString, { cwd }, (error, stdout, stderr) => {
+    exec(execString, { cwd, env: options.env }, (error, stdout, stderr) => {
       if (!error || (error && stderr === '')) {
         resolve(formatResults(stdout));
       } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type Options = LocatorOptions & {
   globs?: Array<string>;
   fileType?: string | Array<string>;
   multiline?: boolean;
+  env?: Record<string, string>;
 };
 
 export type RipgrepJsonSubmatch = {


### PR DESCRIPTION
With this feature, users can specify $PATH to locate the ripgrep bin.

```ts
import { ripGrep as rg } from 'ripgrep-js';
import * as path from "path";

const rgFolderPath = 'xxx';

rg('path/to/search', {
  string: 'xxx',
  env: {
    ...process.env,
    // https://github.com/nodejs/node/issues/34667#issuecomment-672863358
    [Object.keys(process.env).find((x) => x.toUpperCase() === "PATH")!]:
      process.env.PATH + path.delimiter + rgFolderPath,
  }
})
```